### PR TITLE
Update to 26.2

### DIFF
--- a/resourcepack/assets/minecraft/shaders/core/particle.vsh
+++ b/resourcepack/assets/minecraft/shaders/core/particle.vsh
@@ -45,7 +45,7 @@ void main() {
     if (isMarker == 1 && (markerPos.x+markerPos.y)%2 == 0) {
         vec2 markerSize = 2.0 / ScreenSize;
 
-        gl_Position = vec4(-1 + (vec2(markerPos) + corners[gl_VertexID % 4]) * markerSize, 0.0, 1.0);
+        gl_Position = vec4(-1 + (vec2(markerPos) + corners[gl_VertexID % 4]) * markerSize, 1.0, 1.0);
 
         sphericalVertexDistance = 0.0;
         cylindricalVertexDistance = 0.0;

--- a/resourcepack/pack.mcmeta
+++ b/resourcepack/pack.mcmeta
@@ -1,8 +1,7 @@
 {
     "pack": {
         "description": "ShaderSelectorV3.0.4\nAdds communication between commands and post processing shaders.",
-        "pack_format": 65,
-        "min_format": 65,
-        "max_format": 65
+        "min_format": 86,
+        "max_format": 86
     }
 }

--- a/resourcepack/pack.mcmeta
+++ b/resourcepack/pack.mcmeta
@@ -2,6 +2,6 @@
     "pack": {
         "description": "ShaderSelectorV3.0.4\nAdds communication between commands and post processing shaders.",
         "min_format": 88,
-        "max_format": 88,
+        "max_format": 88
     }
 }

--- a/resourcepack/pack.mcmeta
+++ b/resourcepack/pack.mcmeta
@@ -1,7 +1,7 @@
 {
     "pack": {
         "description": "ShaderSelectorV3.0.4\nAdds communication between commands and post processing shaders.",
-        "min_format": 86,
-        "max_format": 86
+        "min_format": 88,
+        "max_format": 88,
     }
 }


### PR DESCRIPTION
According to the feedback server, as of 26.2-snapshot-1:
> We now use reverse-Z everywhere, which means all of your depth comparisons need to be inverted

This PR one-minus's the z coordinate of `gl_Position` for marker pixels in `particle.vsh` so that things still work. It also updates the resource pack format number for 26.2.

The pack as is works without issue for OpenGL and Vulkan with this fix.